### PR TITLE
Add bin/unassigned-pulls.js

### DIFF
--- a/bin/unassigned-pulls.js
+++ b/bin/unassigned-pulls.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+/*
+ * Example usage:
+ *
+ *  $ bin/unassigned-pulls.js config.json
+ *
+ * See `projects/loopback.json` for an example configuration.
+ */
+
+var fs = require('fs');
+var async = require('async');
+var github = require('../lib/create-client');
+
+var configFile = process.argv[2];
+if (!configFile) {
+  console.log('Missing required argument <config.json>');
+  printUsage();
+}
+
+var errors = [];
+
+var projectConfig = JSON.parse(fs.readFileSync(configFile));
+async.each(
+  projectConfig.repos,
+  queryRepository,
+  function(err) {
+    if (err) errors.push(err);
+    if (errors.length) {
+      console.error('\u001b[31m*** Failed ***');
+      errors.forEach(function(e) { console.log(e); });
+      console.log('\u001b[39m');
+    } else {
+      console.log('Done.');
+    }
+  }
+);
+
+function printUsage() {
+  console.log();
+  console.log('Usage:')
+  console.log();
+  console.log('    $ bin/unassigned-pulls.js <config.json>');
+  console.log();
+  process.exit(1);
+}
+
+function queryRepository(repo, done) {
+  var segments = repo.split('/');
+  var repoOwner = segments[0];
+  var repoName = segments[1];
+
+  if (!(repoOwner && repoName)) {
+    var msg = 'Invalid repo `' + repo + '`:' +
+      ' does not match `owner/name` format.';
+    errors.push(new Error(msg));
+    return done();
+  }
+
+  github.pullRequests.getAll(
+    {
+      per_page: 100,
+      user: repoOwner,
+      repo: repoName,
+      state: 'open',
+    }, function(err, pulls) {
+      if (err) {
+        err.action = 'pullRequests.getAll';
+        err.repo = repoName;
+        errors.push(err);
+        return done();
+      }
+
+      async.each(
+        pulls,
+        function(pr, next) {
+          checkPullRequest(repoOwner, repoName, pr, next);
+        },
+        done);
+    });
+}
+
+function checkPullRequest(repoOwner, repoName, pr, done) {
+  if (pr.assignee) return done();
+
+  github.issues.getIssueLabels({
+    user: repoOwner,
+    repo: repoName,
+    number: pr.number
+  }, function(err, labels) {
+    if (err) {
+      err.action = 'issues.getIssueLabels';
+      err.repo = repoName;
+      err.pullId = pr.id;
+      errors.push(err);
+      return done();
+    }
+
+    var labelNames = labels.map(function(l) { return l.name; });
+    console.log("%s %j", pr.html_url, labelNames);
+    done();
+  });
+}


### PR DESCRIPTION
The script lists all pull requests that are not assigned to any developer.

Apparently "non-collaborators PR" detection in Waffle is broken, it is not adding the label to new PRs. This script makes it easy to find forgotten PRs (not only from community).

Sample output:

```
$ bin/unassigned-pulls.js projects/loopback.json
https://github.com/strongloop/strong-gateway/pull/20 ["#review"]
https://github.com/strongloop/loopback-boot/pull/92 []
https://github.com/strongloop/strong-remoting/pull/156 ["#review"]
https://github.com/strongloop/loopback/pull/1005 ["#community contribution"]
https://github.com/strongloop/loopback/pull/1001 ["#review"]
https://github.com/strongloop/loopback/pull/980 ["#sprint63"]
https://github.com/strongloop/loopback/pull/979 []
https://github.com/strongloop/loopback-testing/pull/26 []
https://github.com/strongloop/loopback-testing/pull/25 []
https://github.com/strongloop/loopback-testing/pull/23 []
https://github.com/strongloop/loopback-datasource-juggler/pull/134 ["api/ux","enhancement"]
```

I have run the script for the loopback project, went through all ~30 unassigned pull requests and labelled and/or assigned them as appropriate.

/cc @chandadharap @raymondfeng @ritch @superkhau 