### PR TITLE
Added GHE enterprise connection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Create `.auth.json` in the directory you will run `bin/sync` from:
 }
 ```
 
+### GitHub Enterprise
+
+To connect to a GHE you will need to add the GHE host to the `.auth.json` file above:
+
+```
+{
+  "username": "github-username",
+  "password": "github-password",
+  "enterprise_host": "github.your-GHE-company.com"
+}
+```
+
 ## bin/sync.js
 
 Synchronize labels and milestones across multiple products.

--- a/lib/create-client.js
+++ b/lib/create-client.js
@@ -16,16 +16,27 @@ auth.password = process.env.GH_PASSWORD || auth.password;
 console.assert(auth.username || auth.token);
 console.assert(auth.password || auth.token);
 
-var github = new GitHubApi({
+var github_params = {
   // required
   version: "3.0.0",
   // optional
   protocol: "https",
 //timeout: 5000,
-
   cachedb: '_cache.db',
   validateCache: false,
-});
+}
+
+ghe_host = auth.enterprise_host
+
+if (ghe_host) {
+  console.info("Connecting to GitHub Enterprise (" + ghe_host + ")..")
+  github_params.host = ghe_host;
+  github_params.pathPrefix = "/api/v3"
+} else {
+  console.info("Connecting to GitHub..")
+}
+
+var github = new GitHubApi(github_params);
 
 if ('token' in auth) {
   github.authenticate({


### PR DESCRIPTION
Added option to connect to GitHub Enterprise by specifying GHE host in `.auth.json.`

If host name is not added then connection will default to `github.com`.

cc @rmg

